### PR TITLE
Add Monitor via Telegraf, VPN on Prowlarr + QBittorrent and Torrentio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .vscode
+.env
+.env.*

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ The orchestrate things I installed [CasaOS](https://casaos.io/) with [Portainer]
 - [Home Assistant](https://www.home-assistant.io/)
 - [Cloudflared](https://github.com/cloudflare/cloudflared)
 - [Tailscale](https://tailscale.com/)
+- [Grafana](http://grafana.com)
+- [InfluxDB](https://www.influxdata.com)
 
 ## Install commands
 
@@ -44,6 +46,15 @@ make update-images
 # force build and recreate all docker-compose services
 make recreate
 ```
+
+### Monitoring
+
+To configure the monitoring setup, I use [Telegraf](https://docs.influxdata.com/telegraf/v1/) from InfluxData which uses InfluxDB through an Grafana setup to visualize my processes data, like CPU, Memory, Storage, Docker, etc.
+
+This setup can be way extended than are now, but I just use to a simple and straightforward setup to monitor my machine which can be easily replicated to another machine if I need.
+
+- [How to install Telegraf](https://docs.influxdata.com/telegraf/v1/install/#download-and-install-telegraf)
+- [How to generate a custom config file based on which plugins I want](https://docs.influxdata.com/telegraf/v1/commands/#run-telegraf-but-only-enable-specific-plugins)
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The orchestrate things I installed [CasaOS](https://casaos.io/) with [Portainer]
 - [Tailscale](https://tailscale.com/)
 - [Grafana](http://grafana.com)
 - [InfluxDB](https://www.influxdata.com)
+- [Gluetun](https://github.com/qdm12/gluetun-wiki/tree/main)
 
 ## Install commands
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,11 @@ services:
       - 9696:9696 # prowlarr
     volumes:
       - ~/data/gluetun:/gluetun
+    devices:
+      - /dev/net/tun:/dev/net/tun
     environment:
       VPN_SERVICE_PROVIDER: protonvpn
-      FIREWALL_VPN_INPUT_PORTS: port
+      VPN_TYPE: openvpn
       OPENVPN_USER: /run/secrets/openvpn-username
       OPENVPN_PASSWORD: /run/secrets/openvpn-password
       SERVER_COUNTRIES: Switzerland

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
       - TZ=America/Sao_Paulo
     volumes:
       - ~/data/bazarr/config:/config
-      - ~/media:/mediaserver
+      - /media/Expansion/Media Server:/mediaserver
     ports:
       - 6767:6767
     restart: unless-stopped
@@ -101,7 +101,7 @@ services:
       - TZ=America/Sao_Paulo
     volumes:
       - ~/data/radarr/config:/config
-      - ~/media:/movies
+      - /media/Expansion/Media Server:/movies
       - ~/downloaded-torrents/Completos:/downloads #optional
     ports:
       - 7878:7878
@@ -116,7 +116,7 @@ services:
       - TZ=America/Sao_Paulo
     volumes:
       - ~/data/sonarr/config:/config
-      - ~/media:/movies
+      - /media/Expansion/Media Server:/movies
       - ~/downloaded-torrents/Completos:/downloads #optional
     ports:
       - 8989:8989

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,11 @@ services:
     image: grafana/grafana
     container_name: grafana
     restart: unless-stopped
-    user: '1000'
+    user: "0"
     ports:
       - 3010:3000
-    environment:
-      GF_INSTALL_PLUGINS: influxdb
+    # environment:
+      # GF_INSTALL_PLUGINS: influxdb Optional
     volumes:
       - ~/data/grafana:/var/lib/grafana
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,42 @@
 version: "3"
 
 services:
+  grafana:
+    image: grafana/grafana
+    container_name: grafana
+    restart: unless-stopped
+    user: '1000'
+    ports:
+      - 3010:3000
+    environment:
+      GF_INSTALL_PLUGINS: influxdb
+    volumes:
+      - ~/data/grafana:/var/lib/grafana
+
+  influxdb2:
+    image: influxdb:2
+    restart: unless-stopped
+    ports:
+      - 8086:8086
+    environment:
+      DOCKER_INFLUXDB_INIT_MODE: setup
+      DOCKER_INFLUXDB_INIT_USERNAME_FILE: /run/secrets/influxdb2-admin-username
+      DOCKER_INFLUXDB_INIT_PASSWORD_FILE: /run/secrets/influxdb2-admin-password
+      DOCKER_INFLUXDB_INIT_ADMIN_TOKEN_FILE: /run/secrets/influxdb2-admin-token
+      DOCKER_INFLUXDB_INIT_ORG: docs
+      DOCKER_INFLUXDB_INIT_BUCKET: home
+    secrets:
+      - influxdb2-admin-username
+      - influxdb2-admin-password
+      - influxdb2-admin-token
+    volumes:
+      - type: volume
+        source: influxdb2-data
+        target: /var/lib/influxdb2
+      - type: volume
+        source: influxdb2-config
+        target: /etc/influxdb2
+
   # MEDIA REQUESTER
   jellyseerr:
     image: fallenbagel/jellyseerr:develop
@@ -112,3 +148,15 @@ services:
     restart: unless-stopped
     privileged: true
     network_mode: host
+
+secrets:
+  influxdb2-admin-username:
+    file: ~/.env.influxdb2-admin-username
+  influxdb2-admin-password:
+    file: ~/.env.influxdb2-admin-password
+  influxdb2-admin-token:
+    file: ~/.env.influxdb2-admin-token
+
+volumes:
+  influxdb2-data:
+  influxdb2-config:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,15 @@
 version: "3"
 
 services:
+  crontab-ui:
+    image: alseambusher/crontab-ui
+    container_name: crontab-ui
+    restart: unless-stopped
+    ports:
+      - 8003:8000
+    volumes:
+      - ~/data/crontab:/crontab-ui/crontabs/
+
   grafana:
     image: grafana/grafana
     container_name: grafana

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,36 @@
 version: "3"
 
 services:
+  gluetun:
+    image: qmcgaw/gluetun
+    container_name: gluetun
+    cap_add:
+      - NET_ADMIN
+    ports:
+      - 8383:8383 # qbittorrent ui
+      - 6881:6881 # qbittorrent
+      - 6881:6881/udp # qbittorrent
+      - 9696:9696 # prowlarr
+    volumes:
+      - ~/data/gluetun:/gluetun
+    environment:
+      VPN_SERVICE_PROVIDER: protonvpn
+      FIREWALL_VPN_INPUT_PORTS: port
+      OPENVPN_USER: /run/secrets/openvpn-username
+      OPENVPN_PASSWORD: /run/secrets/openvpn-password
+      SERVER_COUNTRIES: Switzerland
+      PORT_FORWARD_ONLY: on
+      VPN_PORT_FORWARDING: on
+    secrets:
+      - openvpn-username
+      - openvpn-password
+    healthcheck:
+      test: ping -c 1 www.google.com || exit 1
+      interval: 60s
+      timeout: 20s
+      retries: 5
+    restart: unless-stopped
+
   crontab-ui:
     image: alseambusher/crontab-ui
     container_name: crontab-ui
@@ -69,8 +99,7 @@ services:
       - TZ=America/Sao_Paulo
     volumes:
       - ~/data/prowlarr/config:/config
-    ports:
-      - 9696:9696
+    network_mode: service:gluetun
     restart: unless-stopped
 
   # DDoS SOLVER
@@ -142,10 +171,7 @@ services:
     volumes:
       - ~/data/qbittorrent/config:/config
       - ~/downloaded-torrents/Completos:/downloads
-    ports:
-      - 8383:8383
-      - 6881:6881
-      - 6881:6881/udp
+    network_mode: service:gluetun
     restart: unless-stopped
 
   homeassistant:
@@ -165,6 +191,10 @@ secrets:
     file: ~/.env.influxdb2-admin-password
   influxdb2-admin-token:
     file: ~/.env.influxdb2-admin-token
+  openvpn-username:
+    file: ~/.env.openvpn-username
+  openvpn-password:
+    file: ~/.env.openvpn-password
 
 volumes:
   influxdb2-data:

--- a/prowlarr/torrentio-brazuca.yml
+++ b/prowlarr/torrentio-brazuca.yml
@@ -1,0 +1,102 @@
+---
+id: torrentio
+name: Torrentio Brazuca
+description: "Torrentio Indexer"
+language: pt-BR
+type: public
+encoding: UTF-8
+followredirect: false
+testlinktorrent: false
+requestDelay: 2
+links:
+  - https://torrentio.strem.fun/
+
+caps:
+  categories:
+    Movies: Movies
+    TV: TV
+
+  modes:
+    search: [q]
+    movie-search: [q, imdbid]
+    tv-search: [q, imdbid, season, ep]
+  allowrawsearch: false
+
+settings:
+  - name: opt_label
+    type: info
+    label: Torrentio Options are Required
+  - name: default_opts
+    type: text
+    label: Torrentio Options
+    default: "providers=eztv,rarbg,comando,bludv|language=portuguese|qualityfilter=hdrall,dolbyvisionwithhdr,threed,480p,other,scr,cam,unknown"
+  - name: rdkey_label
+    type: info
+    label: Real-Debrid API Key Required
+  - name: rd_key
+    type: text
+    label: Real-Debrid API Key
+    default: ""
+
+search:
+  headers:
+    User-Agent: ["Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0"]
+  paths:
+    - path: "{{ if .Query.IMDBID }}{{ .Config.default_opts }}|realdebrid={{ .Config.rd_key }}|debridoptions=nodownloadlinks/stream/movie/{{ .Query.IMDBID }}.json{{ else }}providers=rarbg,1337x|sort=size|qualityfilter=brremux,hdrall,dolbyvision,4k,720p,480p,other,scr,cam,unknown|sort=size|limit=1|realdebrid={{ .Config.rd_key }}|debridoptions=nodownloadlinks/stream/movie/tt0137523.json{{ end }}"
+      method: get
+      response:
+        type: json
+        noResultsMessage: '"streams": []'
+      categories: [Movies]
+    - path: "{{ if .Query.IMDBIDShort }}{{ .Config.default_opts }}{{else}}providers=rarbg,1337x|sort=size|qualityfilter=brremux,hdrall,dolbyvision,4k,720p,480p,other,scr,cam,unknown|limit=1{{ end }}|realdebrid={{ .Config.rd_key }}|debridoptions=nodownloadlinks/stream/series/tt{{ if .Query.IMDBIDShort }}{{ .Query.IMDBIDShort }}{{ else }}1632701{{ end }}:{{ if .Query.Season }}{{ .Query.Season }}{{ else }}1{{ end }}:{{ if .Query.Ep }}{{ .Query.Ep }}{{ else }}1{{ end }}.json"
+      method: get
+      response:
+        type: json
+        noResultsMessage: '"streams": []'
+      categories: [TV]
+
+  rows:
+    selector: streams
+    missingAttributeEqualsNoResults: true
+
+  fields:
+    title:
+      selector: title
+      filters:
+        - name: split
+          args: ["\n", 0]
+        - name: append
+          args: ".PT-BR"
+    year:
+      selector: title
+      filters:
+        - name: regexp
+          args: "(\\b(19|20)\\d\\d\\b)"
+    category_is_tv_show:
+      text: "{{ .Result.title }}"
+      filters:
+        - name: regexp
+          args: "\\b(S\\d+(?:E\\d+)?)\\b"
+    category:
+      text: "{{ if .Result.category_is_tv_show }}TV{{ else }}Movies{{ end }}"
+    infohash:
+      selector: infoHash
+    size:
+      selector: title
+      filters:
+        - name: regexp
+          args: "\\b(\\d+(?:\\.\\d+)? [MG]B)\\b"
+    seeders:
+      selector: title
+      filters:
+        - name: regexp
+          args: "(\\uD83D\\uDC64 \\d+)"
+    date:
+      text: "Apr. 18th '11"
+      filters:
+        - name: re_replace
+          args: ["st|nd|rd|th", ""]
+        - name: replace
+          args: ["'", ""]
+        - name: dateparse
+          args: "MMM. d yy"

--- a/shell/docker-clean-up-images.sh
+++ b/shell/docker-clean-up-images.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# This script cleans up old Docker images, containers, and networks.
+
+# Step 1: Remove dangling images (untagged images that are not referenced by any container)
+echo "Removing dangling images..."
+docker image prune -f
+
+# Step 2: Remove unused images (not associated with any containers)
+echo "Removing unused images..."
+docker image prune -a -f
+
+# Step 3: Remove unused containers
+echo "Removing stopped containers..."
+docker container prune -f
+
+# Step 4: Remove unused volumes
+echo "Removing unused volumes..."
+docker volume prune -f
+
+# Step 5: Remove unused networks
+echo "Removing unused networks..."
+docker network prune -f
+
+echo "Docker cleanup completed."


### PR DESCRIPTION
- Add basic Grafana setup to use InfluxDB + Telegraf to monitor the system.
- Add a custom `torrentio` setup to support some Brazil torrent providers through Prowlarr, inspired by [dreulavelle](https://github.com/dreulavelle/Prowlarr-Indexers).
- Add Gluetun to apply VPN on qBittorrent and Prowlarr.